### PR TITLE
feat: replace alternative latex syntax with standard syntax

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,29 @@ import MarkdownLatexWrapper from "./components/MarkdownLatexWrapper";
 const mdLatexText = `
 ### Markdown with LaTeX
 
+#### Example 1 with \`$\` delimiter
+
 Given a **formula** below
 $$
 s = ut + \\frac{1}{2}at^{2}
 $$
 Calculate the value of $s$ when $u = 10\\frac{m}{s}$ and $a = 2\\frac{m}{s^{2}}$ at $t = 1s$
+
+#### Example 2 with \`[\`, \`]\`, \`(\` and \`)\` delimiters
+
+The area \\( A \\) of a circle is given by the formula:
+
+\\[ A = \\pi r^2 \\]
+
+where \\( r \\) is the radius of the circle. For a circle with a radius of 5, we substitute \\( r = 5 \\) into the formula:
+
+\\[ A = \\pi (5)^2 \\]
+\\[ A = \\pi \\times 25 \\]
+\\[ A = 25\\pi \\]
+
+Therefore, the area of the circle is:
+
+\\[ \\boxed{25\\pi} \\]
 `;
 
 const App = () => {

--- a/src/components/MarkdownLatexWrapper.tsx
+++ b/src/components/MarkdownLatexWrapper.tsx
@@ -1,31 +1,34 @@
 import ReactMarkdown from "react-markdown";
-import rehypeKatex from 'rehype-katex';
-import remarkMath from 'remark-math';
-import 'katex/dist/katex.min.css';
+import rehypeKatex from "rehype-katex";
+import remarkMath from "remark-math";
+import "katex/dist/katex.min.css";
+
+const preprocessMarkdownText = (text: string) =>
+  text
+    .replace(/\\\[/g, "$$")
+    .replace(/\\\]/g, "$$")
+    .replace(/\\\(/g, "$")
+    .replace(/\\\)/g, "$");
 
 /**
  * Renders markdown content passed as children.
  *
  * @param children markdown text to render
  */
-const MarkdownLatexWrapper = ({
-	children
-}: {
-	children: React.ReactNode
-}) => {
-    // ensures that markdownText is a string
-	const markdownText = typeof children === "string" ? children : "";
-	return (
-		<ReactMarkdown
-			components={{
-				p: ({ ...props }) => <>{props.children}</>,
-			}}
-			remarkPlugins={[remarkMath]}
-            rehypePlugins={[rehypeKatex]}
-		>
-			{markdownText}
-		</ReactMarkdown>
-	);
+const MarkdownLatexWrapper = ({ children }: { children: React.ReactNode }) => {
+  // ensures that markdownText is a string
+  const markdownText = typeof children === "string" ? children : "";
+  return (
+    <ReactMarkdown
+      components={{
+        p: ({ ...props }) => <>{props.children}</>,
+      }}
+      remarkPlugins={[remarkMath]}
+      rehypePlugins={[rehypeKatex]}
+    >
+      {preprocessMarkdownText(markdownText)}
+    </ReactMarkdown>
+  );
 };
 
 export default MarkdownLatexWrapper;


### PR DESCRIPTION
#### Description

LaTeX syntax comes in different flavors. Current implementation only supports the `$` (inline) and `$$` (block) syntax. Often we also come across the `\(` & `\)` (inline) and `\[` & `\]` (block) syntax. This syntax is now also supported.

Closes #(issue)

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Replace the text in the markdown text accordingly with dollar sign syntax for `rehype-katex` to correctly process it.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)